### PR TITLE
upgrade rubocop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -73,8 +73,7 @@ Lint/EmptyInterpolation:
 Lint/EndAlignment:
   Description: 'Align ends correctly.'
   Enabled: true
-  EnforcedStyleAlignWith: start_of_line
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Lint/EndInMethod:
   Description: 'END blocks should not be placed inside method definitions.'
@@ -470,6 +469,7 @@ Style/CaseIndentation:
   Description: 'Indentation of when in a case/when/[else/]end.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-when-to-case'
   Enabled: true
+  EnforcedStyle: end
 
 Style/CharacterLiteral:
   Description: 'Checks for uses of character literals.'
@@ -720,7 +720,7 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: true
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
   Enabled: true


### PR DESCRIPTION
We are still using options from rubocop 46, current version supported by codeclimate is 48