### PR TITLE
Increase max characters on line for rubocop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -234,8 +234,8 @@ Metrics/CyclomaticComplexity:
   Enabled: true
 
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Description: 'Limit lines to 120 characters.'
+  Max: 120
   Enabled: true
 
 Metrics/MethodLength:


### PR DESCRIPTION
120 characters per line in accordance with Github file viewer length
