### PR TITLE
Add default ignored paths for AllCops

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3,8 +3,10 @@ AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.4
   Exclude:
-    - specs/**/*.spec
-    - specs/**/*.cpt
+    - 'node_modules/**/*'
+    - 'vendor/**/*'
+    - 'specs/**/*.spec'
+    - 'specs/**/*.cpt'
 
 #################### Lint ################################
 


### PR DESCRIPTION
- adding custom exclude for AllCops overrode default excluded paths
- add the default excluded paths to rubocop config

When I added the custom paths of files to ignore, it overrode the default excluded paths for rubocop. Added those default paths manually to the Exclude section of AllCops

the default config can be seen here  https://raw.githubusercontent.com/bbatsov/rubocop/master/config/default.yml