### PR TITLE
Maybe turn off this lambda rule?

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -714,7 +714,7 @@ Style/Lambda:
 Style/LambdaCall:
   Description: 'Use lambda.call(...) instead of lambda.(...).'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#proc-call'
-  Enabled: true
+  Enabled: false
 
 Style/LeadingCommentSpace:
   Description: 'Comments should start with a space.'


### PR DESCRIPTION
I think we should turn this one off.
Right now it requires us to do:
`some_lambda.call(args...)`
instead of just:
`some_lambda.(args...)`

I like the shorter option (just the `.` operator instead of the `call` method) because:
1) It is similar to Elixir and many other languages
2) It makes it more apparent that the variable the operator is being used on is a lambda as opposed to some custom method on the class named `call`

What does everyone else think?