### PR TITLE
Removed comment causing additional codeclimate issues to appear

### DIFF
--- a/credo.exs
+++ b/credo.exs
@@ -48,7 +48,7 @@
         # For some checks, like AliasUsage, you can only customize the priority
         # Priority values are: `low, normal, high, higher`
         {Credo.Check.Design.AliasUsage, false},
-        # Removed due to discussion about module name collisions 
+        # Removed due to discussion about module name collisions
         #   (ie DateTime, Ecto.DateTime)
 
         # For others you can set parameters
@@ -58,9 +58,6 @@
         # set the `excluded_macros` parameter to `[:schema, :setup, :test]`.
         {Credo.Check.Design.DuplicatedCode, excluded_macros: []},
 
-        # You can also customize the exit_status of each check.
-        # If you don't want TODO comments to cause `mix credo` to fail, just
-        # set this value to 0 (zero).
         {Credo.Check.Design.TagTODO, exit_status: 2},
         {Credo.Check.Design.TagFIXME},
 


### PR DESCRIPTION
Each of our .codeclimate.yml files is configured to copy the credo file from
this code_styles repo into the directory the static analysis is being run on.
This TODO in a comment was then triggering an issue from the FIXME engine
in new elixir repos