### PR TITLE
Ruby Safe Assignment in Condition, JSX 1expression/line

### DIFF
--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -6,6 +6,7 @@
 
 * [constructor-super](#constructor-super)
 * [jsx-quotes](#jsx-quotes)
+* [jsx-one-expression-per-line](#jsx-one-expression-per-line)
 * [max-statements](#max-statements)
 * [no-case-declarations](#no-case-declarations)
 * [no-class-assign](#no-class-assign)
@@ -276,6 +277,10 @@
   * enforce the consistent use of double quotes in JSX attributes
   [read more](https://eslint.org/docs/rules/jsx-quotes)
 
+## jsx-one-expression-per-line
+  * limits every line in JSX to one expression each.
+  [read more](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-one-expression-per-line.md)
+  
 ## max-statements
   * enforce a maximum number of statements allowed in function blocks
   [read more](https://eslint.org/docs/rules/max-statements)

--- a/RUBY.md
+++ b/RUBY.md
@@ -22,6 +22,7 @@ it at [this commit](6e4c2cf7eb7319b4d8f203d9c3839d839c46313://github.com/airbnb/
   1. [Conditional Expressions](#conditional-expressions)
     1. [Conditional keywords](#conditional-keywords)
     1. [Ternary operator](#ternary-operator)
+    1. [Safe Assignment in condition](#safe-assignment-in-condition)
   1. [Syntax](#syntax)
   1. [Naming](#naming)
   1. [Classes](#classes)
@@ -815,6 +816,33 @@ In either case:
       something
     else
       something_else
+    end
+    ```
+    
+### Safe assignment in condition
+
+* <a name="safe-assignment-in-condition"></a>Don't use the return value of an assignment (`=`)
+    unless the assignment is wrapped in parentheses.
+    <sup>[[link](#safe-assignment-in-condition)]</sup>
+
+    ```ruby
+    # bad (+ a warning)
+    if v = array.grep(/foo/)
+      do_something(v)
+      # some code
+    end
+    
+    # good (MRI would still complain, but RuboCop won't)
+    if (v = array.grep(/foo/))
+      do_something(v)
+      # some code
+    end
+    
+    # good
+    v = array.grep(/foo/)
+    if v
+      do_something(v)
+      # some code
     end
     ```
 


### PR DESCRIPTION
Note: Jsx rule requires extending eslint

`JSX one expression per line`: It's already pretty much the case everywhere with the odd exception

`Ruby Safe Assignment in Condition`: It's not the case anywhere - it could be adopted for rubocop and code scanning ease (http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/SafeAssignment).