### PR TITLE
Allow trailing commas in multi-line [] and {}.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1098,7 +1098,7 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInLiteral:
   Description: 'Checks for trailing comma in literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
-  Enabled: true
+  Enabled: false
 
 Style/TrailingWhitespace:
   Description: 'Avoid trailing whitespace.'


### PR DESCRIPTION
Having trailing commas in multi-line arrays and hashs makes diffs only
touch the lines that are related, and makes editing in general much more
consistent. We should still not use trailing commas in single line
literals, even if rubocop now allows it.

This rule in Rubocop makes very little sense, and is mostly based on
being consistent with [1,2,3] not being written [1,2,3,]. AFAIK, there
is no way to tell Rubocop to allow trailing commas in multi-line
literals, without also enabling it for single line literals. I'm pretty
sure there is an issue open about this in the rubocop repo on GH, but it
was clear most people with power didn't care, or want to change it.