### PR TITLE
Config rubocop and eslint with max line length of 120

### DIFF
--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -7,6 +7,7 @@
 * [constructor-super](#constructor-super)
 * [jsx-quotes](#jsx-quotes)
 * [jsx-one-expression-per-line](#jsx-one-expression-per-line)
+* [max-len](#max-len)
 * [max-statements](#max-statements)
 * [no-case-declarations](#no-case-declarations)
 * [no-class-assign](#no-class-assign)
@@ -276,6 +277,10 @@
 ## jsx-quotes
   * enforce the consistent use of double quotes in JSX attributes
   [read more](https://eslint.org/docs/rules/jsx-quotes)
+
+## max-len
+  * enforce a maximum line length
+  [read more](https://eslint.org/docs/rules/max-len)
 
 ## max-statements
   * enforce a maximum number of statements allowed in function blocks

--- a/RUBY.md
+++ b/RUBY.md
@@ -302,7 +302,9 @@ it at [this commit](6e4c2cf7eb7319b4d8f203d9c3839d839c46313://github.com/airbnb/
 ## Line Length
 
 * Keep each line of code to a readable length. Unless
-  you have a reason to, keep lines to fewer than 80 characters.
+  you have a reason to, keep lines to fewer than 120 (not 80) characters
+  to bias in favor of (longer) descriptive names with fewer abbreviations
+  that can make an 80 character limit too restrictive
   <sup>[[link](#line-length)]</sup>
   <sup>[[rubocop](://github.com/ForwardFinancing/code_styles/blob/master/rubocop.yml#L234-L237)]</sup>
 

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -35,6 +35,7 @@
     "no-alert": 0,
     "no-lone-blocks": 0,
     "jsx-quotes": 1,
+    "max-len": ["error", { "code": 120 }],
     "max-statements": [1, 30],
     "react/display-name": [ 1, {"ignoreTranspilerName": false }],
     "react/forbid-prop-types": [1, {"forbid": ["any"]}],

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -239,9 +239,10 @@ Metrics/CyclomaticComplexity:
   Enabled: true
 
 Metrics/LineLength:
-  Description: 'Limit lines to 80 characters.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#80-character-limits'
+  Description: 'Limit lines to 120 characters.'
+  StyleGuide: 'https://github.com/ForwardFinancing/code_styles/blob/master/RUBY.md#line-length'
   Enabled: true
+  Max: 120
   Exclude:
     - step_implementations/*_spec.rb
 


### PR DESCRIPTION
- Config settings added because we were previously using default settings
- Did my best to update readme and doc links
- Config changes tested locally using `codeclimate` cli