### PR TITLE
Disable nesting and optional & rules

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -109,9 +109,7 @@ linters:
     convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
 
   NestingDepth:
-    enabled: true
-    max_depth: 3
-    ignore_parent_selectors: false
+    enabled: false
 
   PlaceholderInExtend:
     enabled: true
@@ -160,8 +158,7 @@ linters:
     allow_element_with_id: false
 
   SelectorDepth:
-    enabled: true
-    max_depth: 3
+    enabled: false
 
   SelectorFormat:
     enabled: true
@@ -234,7 +231,7 @@ linters:
     enabled: true
 
   UnnecessaryParentReference:
-    enabled: true
+    enabled: false
 
   UrlFormat:
     enabled: true


### PR DESCRIPTION
Two primary reasons people cite for having the nesting rules are:
1. It makes it harder to maintain
2. Performance is worse with longer selectors

For the first point, while this is true, the having too flat of selector hierarchy can lead to lots of unintentional overlap of styling rules due to overlapping selectors.  Since stylesheets are global, there's no guarantee that a selector one developer uses will not affect the styling in a completely different part of the codebase (this is incredibly difficult to test).  Using nested selectors where you are more specific about what you're modifying reduces side effects in styling.  Removing this rule is not suggesting that we use the most specific selectors at every point possible - it's just removing the suggestion that nesting is always bad practice.

For the second point, this is true, however, the performance differences are [pretty negligible](https://ecss.io/appendix1.html).  With modern browsers and tooling, this should not be the primary concern of developers, especially since collecting styling is such a tiny fraction of the overal render time.

Also removing the rule that prevents the use of `&` when it's not strictly necessary.  Enforcing this rule would require developers to understand when it is necessary vs when it is optional.  Oftentimes, it can provide more clarity when reading sass to add the optional `&`.  Removing this rule is not suggesting that it should always be used, only that we don't enforce its removal and allow developers the freedom to use it should they feel it adds clarity.