### PR TITLE
Exclude kwargs from parameter list length rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -261,6 +261,7 @@ Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: true
+  CountKeywordArgs: false
 
 Metrics/PerceivedComplexity:
   Description: >-


### PR DESCRIPTION
The existing rule prohibits methods from having more than 5 arguments.
This change to the rule's configurable attributes excludes keyword arguments from that count
Documentation: https://docs.rubocop.org/rubocop/0.89/cops_metrics.html#metricsparameterlists

Rationale:
Sometimes we just need a method to take lots of parameters, some of which may be optional.
The existing pattern people use to reduce argument count is to combine the optional and/or less important arguments into a hash ie
`def something(very, important, parameters, not, so, important, parameters)`
becomes
`def something(very, important, parameters, not_so_important_parameters: {})`

The options/extra arguments hash then has to be handled inside the method.

Keyword args solve a lot of the problems with long parameter lists because they enable us to exclude optional parameters, and make it so we don't have to remember the order of parameters in order to know each parameters meaning at the spot a method is called