### PR TITLE
Remove obsolete/invalid rules for Rubocop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1022,6 +1022,11 @@ Style/SpaceAroundOperators:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'
   Enabled: true
 
+Style/SpaceInsideBrackets:
+  Description: 'No spaces after [ or before ].'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-spaces-braces'
+  Enabled: true
+
 Style/SpaceInsideHashLiteralBraces:
   Description: "Use spaces inside hash literal braces - or don't."
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#spaces-operators'


### PR DESCRIPTION
After getting this message on one of my PRs in UW Service: https://codeclimate.com/repos/5aa9546fb844fa029d00f48c/pull/30

Looks like the rule `Lint/InvalidCharacterLiteral`  is obsolete, so I am removing it. I couldn't specifically find this `Layout/SpaceInsideBrackets`, the only one that's kind of similar is `Style/SpaceInsideBrackets` but not removing since its not an exact match. If that's needed as well from anyone else' understanding, feel free to let me know in a comment.