### PR TITLE
[FUN-686] Update Lint/Eval to be Security/Eval

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -89,7 +89,7 @@ Lint/EnsureReturn:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
   Enabled: true
 
-Lint/Eval:
+Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 


### PR DESCRIPTION
Fix for:
```
/code/.rubocop.yml: Lint/Eval has the wrong namespace - should be Security
```