### PR TITLE
Bump TargetRubyVersion to 2.7

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,7 +1,7 @@
 
 AllCops:
   DisabledByDefault: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - 'node_modules/**/*'
     - 'vendor/**/*'


### PR DESCRIPTION
This allows us to use new syntax from Ruby 2.7+, such as argument forwarding.